### PR TITLE
Fixed error, likely caused by an unloaded RPUIVibrationBodyWithButton

### DIFF
--- a/lib/ui/QuestionBody/rpui_vibration_body_with_button.dart
+++ b/lib/ui/QuestionBody/rpui_vibration_body_with_button.dart
@@ -31,13 +31,15 @@ class _RPUIVibrationBodyWithButtonState
 
   @override
   void initState() {
-    _loadVibrationDuration();
     super.initState();
+    _loadVibrationDuration();
   }
 
   void _loadVibrationDuration() async {
     int vibrationDuration = await _settingsRepository.getVibrationDuration();
-    setState(() => _vibrationDuration = vibrationDuration);
+    if (mounted) {
+      setState(() => _vibrationDuration = vibrationDuration);
+    }
   }
 
   @override


### PR DESCRIPTION
I think more than one instance of RPUIVibrationBodyWithButton is created with the first instance being unloaded very quickly. This causes setState to fail. Would like to test it better to be sure, but don't have time until next week